### PR TITLE
fix serializing idx field for IndexerBaseParams

### DIFF
--- a/vertex_protocol/indexer_client/types/query.py
+++ b/vertex_protocol/indexer_client/types/query.py
@@ -51,6 +51,9 @@ class IndexerBaseParams(VertexBaseModel):
     max_time: Optional[int]
     limit: Optional[int]
 
+    class Config:
+        allow_population_by_field_name = True
+
 
 class IndexerSubaccountHistoricalOrdersParams(IndexerBaseParams):
     """


### PR DESCRIPTION
It looks like `Field` does not serialize properly by default, `idx` and `submission_idx` are not included in the request parameters even though it's populated on `IndexerBaseParams `.

This PR sets `allow_population_by_field_name = True`, which fixes this issue.