### PR TITLE
bump: v3.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "vertex-protocol"
-version = "2.1.9"
+version = "3.0.0"
 description = "Vertex Protocol SDK"
 authors = ["Jeury Mejia <jeury@vertexprotocol.com>"]
 homepage = "https://vertexprotocol.com/"


### PR DESCRIPTION
- adds `trigger client` (https://docs.vertexprotocol.com/developer-resources/api/trigger)